### PR TITLE
separate data fetch logic from merging and backtesting data

### DIFF
--- a/src/lib/price-gen/geometricBrownianMotion.ts
+++ b/src/lib/price-gen/geometricBrownianMotion.ts
@@ -45,10 +45,9 @@ export function generateGbm({
   // Implement GBM
   const S = [S0];
   for (let i = 1; i < N; i++) {
-    const t = dt * i;
     const W = Math.sqrt(dt) * randn_bm();
     const St =
-      S[S.length - 1] * Math.exp((mu - sigma ** 2 / 2) * t + sigma * W);
+      S[S.length - 1] * Math.exp((mu - sigma ** 2 / 2) * dt + sigma * W);
     S.push(St);
   }
   return S;


### PR DESCRIPTION
This PR allows the backtester to use data sources that are not synced.
Note: a datasource may even have the same resolution but varying data limits - this would cause the previous backtester code to break. 
By fetching all data for all datasources first, we remove any dependency requirements between various data sources.
This should not impact backtest speed since we were not fetching & running tests in parallel.