### PR TITLE
A more efficient data srouce snapshot merge

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "node": ">=14.0"
   },
   "scripts": {
-    "start": "ts-node ./src/index.ts",
+    "start": "ts-node ./src/simple.ts",
     "build": "tsc --build tsconfig.build.json",
     "clean": "git clean -dfqX",
     "install-with-npm-8.5": "npm i -g npm@^8.5.0 && npm i",

--- a/src/lib/backtest.ts
+++ b/src/lib/backtest.ts
@@ -116,14 +116,18 @@ export class Backtest {
     const unique = Array.from(new Set(timestamps)).sort((a, b) => a - b);
 
     const mergedData = unique.map((ts) => {
-      // find all datasources that have a snapshot at this timestamp
-      const dsWithSnapshots = allData.filter(
-        (ds) => ds.findIndex((e) => e.timestamp === ts) !== -1,
-      );
       // grab data from each datasource at this timestamp
-      const data = dsWithSnapshots.map(
-        (ds) => ds.find((e) => e.timestamp === ts)?.data,
-      );
+      const data = allData
+        .map((ds) => {
+          const index = ds.findIndex((e) => e.timestamp === ts);
+          if (index === -1) return;
+          const data = ds[index]?.data;
+          // remove data from the array so we don't have to iterate through it again
+          ds.splice(index, 1);
+          return data;
+        })
+        .filter((e) => e);
+
       return {
         timestamp: ts,
         data: Object.assign({}, ...data),


### PR DESCRIPTION
I've found that merging a large dataset can be time-consuming since we search through all the data for each timestamp.
This PR removes processed snapshots from the data sources reducing the merge time. 